### PR TITLE
fix: filter for DIDCommMessaging service type

### DIFF
--- a/didcomm_messaging/routing.py
+++ b/didcomm_messaging/routing.py
@@ -28,6 +28,8 @@ class RoutingService:
         services = []
         if did_doc.service:  # service is not guaranteed to exist
             for did_service in did_doc.service:
+                if did_service.type != "DIDCommMessaging":
+                    continue
                 if "didcomm/v2" in did_service.service_endpoint.accept:
                     services.append(did_service)
         if not services:


### PR DESCRIPTION
This prevents exceptions that may occur if the service type is did-communication instead of DIDCommMessaging