### PR TITLE
refactor: make services more flexible

### DIFF
--- a/didcomm_messaging/__init__.py
+++ b/didcomm_messaging/__init__.py
@@ -46,6 +46,74 @@ class UnpackResult:
     sender_kid: Optional[str] = None
 
 
+class DIDCommMessagingService(Generic[P, S]):
+    """Main entrypoint for DIDComm Messaging."""
+
+    def service_to_target(self, service: DIDCommV2Service) -> str:
+        """Convert a service to a target uri.
+
+        This is a very simple implementation that just returns the first one.
+        """
+        if isinstance(service.service_endpoint, list):
+            service_endpoint = service.service_endpoint[0]
+        else:
+            service_endpoint = service.service_endpoint
+
+        return service_endpoint.uri
+
+    async def pack(
+        self,
+        crypto: CryptoService[P, S],
+        resolver: DIDResolver,
+        secrets: SecretsManager[S],
+        packaging: PackagingService[P, S],
+        routing: RoutingService,
+        message: dict,
+        to: str,
+        frm: Optional[str] = None,
+        **options,
+    ):
+        """Pack a message."""
+        # TODO crypto layer permits packing to multiple recipients; should we as well?
+
+        encoded_message = await packaging.pack(
+            crypto,
+            resolver,
+            secrets,
+            json.dumps(message).encode(),
+            [to],
+            frm,
+            **options,
+        )
+
+        forward, services = await routing.prepare_forward(
+            crypto, packaging, resolver, secrets, to, encoded_message
+        )
+        return PackResult(forward, services)
+
+    async def unpack(
+        self,
+        crypto: CryptoService[P, S],
+        resolver: DIDResolver,
+        secrets: SecretsManager[S],
+        packaging: PackagingService[P, S],
+        encoded_message: bytes,
+        **options,
+    ) -> UnpackResult:
+        """Unpack a message."""
+        unpacked, metadata = await packaging.unpack(
+            crypto, resolver, secrets, encoded_message, **options
+        )
+        message = json.loads(unpacked.decode())
+        return UnpackResult(
+            message,
+            encrytped=bool(metadata.method),
+            authenticated=bool(metadata.sender_kid),
+            recipient_kid=metadata.recip_key.kid,
+            sender_kid=metadata.sender_kid,
+        )
+
+
 class DIDCommMessaging(Generic[P, S]):
     """Main entrypoint for DIDComm Messaging."""
 
@@ -63,38 +131,39 @@ class DIDCommMessaging(Generic[P, S]):
         self.resolver = resolver
         self.packaging = packaging
         self.routing = routing
+        self.dmp = DIDCommMessagingService()
 
-    def service_to_target(self, service: DIDCommV2Service) -> str:
-        """Convert a service to a target uri.
-
-        This is a very simple implementation that just returns the first one.
-        """
-        if isinstance(service.service_endpoint, list):
-            service_endpoint = service.service_endpoint[0]
-        else:
-            service_endpoint = service.service_endpoint
-
-        return service_endpoint.uri
-
-    async def pack(self, message: dict, to: str, frm: Optional[str] = None, **options):
+    async def pack(
+        self,
+        message: dict,
+        to: str,
+        frm: Optional[str] = None,
+        **options,
+    ) -> PackResult:
         """Pack a message."""
-        # TODO crypto layer permits packing to multiple recipients; should we as well?
-
-        encoded_message = await self.packaging.pack(
-            json.dumps(message).encode(), [to], frm, **options
+        return await self.dmp.pack(
+            self.crypto,
+            self.resolver,
+            self.secrets,
+            self.packaging,
+            self.routing,
+            message,
+            to,
+            frm,
+            **options,
         )
 
-        forward, services = await self.routing.prepare_forward(to, encoded_message)
-        return PackResult(forward, services)
-
-    async def unpack(self, encoded_message: bytes, **options) -> UnpackResult:
+    async def unpack(
+        self,
+        encoded_message: bytes,
+        **options,
+    ) -> UnpackResult:
         """Unpack a message."""
-        unpacked, metadata = await self.packaging.unpack(encoded_message, **options)
-        message = json.loads(unpacked.decode())
-        return UnpackResult(
-            message,
-            encrytped=bool(metadata.method),
-            authenticated=bool(metadata.sender_kid),
-            recipient_kid=metadata.recip_key.kid,
-            sender_kid=metadata.sender_kid,
+        return await self.dmp.unpack(
+            self.crypto,
+            self.resolver,
+            self.secrets,
+            self.packaging,
+            encoded_message,
+            **options,
         )

--- a/didcomm_messaging/packaging.py
+++ b/didcomm_messaging/packaging.py
@@ -28,19 +28,8 @@ class PackagingServiceError(Exception):
 class PackagingService(Generic[P, S]):
     """DIDComm Messaging interface."""
 
-    def __init__(
-        self,
-        resolver: DIDResolver,
-        crypto: CryptoService[P, S],
-        secrets: SecretsManager[S],
-    ):
-        """Initialize the KMS."""
-        self.resolver = resolver
-        self.crypto = crypto
-        self.secrets = secrets
-
     async def extract_packed_message_metadata(  # noqa: C901
-        self, enc_message: Union[str, bytes]
+        self, enc_message: Union[str, bytes], secrets: SecretsManager[S]
     ) -> PackedMessageMetadata:
         """Extract metadata from a packed DIDComm message."""
         try:
@@ -61,7 +50,7 @@ class PackagingService(Generic[P, S]):
         sender_kid = None
         recip_key = None
         for kid in wrapper.recipient_key_ids:
-            recip_key = await self.secrets.get_secret_by_kid(kid)
+            recip_key = await secrets.get_secret_by_kid(kid)
             if recip_key:
                 break
 
@@ -97,40 +86,42 @@ class PackagingService(Generic[P, S]):
         return PackedMessageMetadata(wrapper, method, recip_key, sender_kid)
 
     async def unpack(
-        self, enc_message: Union[str, bytes]
+        self,
+        crypto: CryptoService[P, S],
+        resolver: DIDResolver,
+        secrets: SecretsManager[S],
+        enc_message: Union[str, bytes],
     ) -> Tuple[bytes, PackedMessageMetadata]:
         """Unpack a DIDComm message."""
-        metadata = await self.extract_packed_message_metadata(enc_message)
+        metadata = await self.extract_packed_message_metadata(enc_message, secrets)
 
         if metadata.method == "ECDH-ES":
             return (
-                await self.crypto.ecdh_es_decrypt(enc_message, metadata.recip_key),
+                await crypto.ecdh_es_decrypt(enc_message, metadata.recip_key),
                 metadata,
             )
 
         if not metadata.sender_kid:
             raise PackagingServiceError("Missing sender key ID")
 
-        sender_vm = await self.resolver.resolve_and_dereference_verification_method(
+        sender_vm = await resolver.resolve_and_dereference_verification_method(
             metadata.sender_kid
         )
-        sender_key = self.crypto.verification_method_to_public_key(sender_vm)
+        sender_key = crypto.verification_method_to_public_key(sender_vm)
 
         return (
-            await self.crypto.ecdh_1pu_decrypt(
-                enc_message, metadata.recip_key, sender_key
-            ),
+            await crypto.ecdh_1pu_decrypt(enc_message, metadata.recip_key, sender_key),
             metadata,
         )
 
-    async def recip_for_kid_or_default_for_did(self, kid_or_did: str) -> P:
+    async def recip_for_kid_or_default_for_did(
+        self, crypto: CryptoService[P, S], resolver: DIDResolver, kid_or_did: str
+    ) -> P:
         """Resolve a verification method for a kid or return default recip."""
         if "#" in kid_or_did:
-            vm = await self.resolver.resolve_and_dereference_verification_method(
-                kid_or_did
-            )
+            vm = await resolver.resolve_and_dereference_verification_method(kid_or_did)
         else:
-            doc = await self.resolver.resolve_and_parse(kid_or_did)
+            doc = await resolver.resolve_and_parse(kid_or_did)
             if not doc.key_agreement:
                 raise PackagingServiceError(
                     "No key agreement methods found; cannot determine recipient"
@@ -146,14 +137,14 @@ class PackagingService(Generic[P, S]):
             else:
                 vm = default
 
-        return self.crypto.verification_method_to_public_key(vm)
+        return crypto.verification_method_to_public_key(vm)
 
-    async def default_sender_kid_for_did(self, did: str) -> str:
+    async def default_sender_kid_for_did(self, resolver: DIDResolver, did: str) -> str:
         """Determine the kid of the default sender key for a DID."""
         if "#" in did:
             return did
 
-        doc = await self.resolver.resolve_and_parse(did)
+        doc = await resolver.resolve_and_parse(did)
         if not doc.key_agreement:
             raise PackagingServiceError(
                 "No key agreement methods found; cannot determine recipient"
@@ -175,21 +166,27 @@ class PackagingService(Generic[P, S]):
 
     async def pack(
         self,
+        crypto: CryptoService[P, S],
+        resolver: DIDResolver,
+        secrets: SecretsManager[S],
         message: bytes,
         to: Sequence[str],
         frm: Optional[str] = None,
         **options,
     ):
         """Pack a DIDComm message."""
-        recip_keys = [await self.recip_for_kid_or_default_for_did(kid) for kid in to]
-        sender_kid = await self.default_sender_kid_for_did(frm) if frm else None
-        sender_key = (
-            await self.secrets.get_secret_by_kid(sender_kid) if sender_kid else None
+        recip_keys = [
+            await self.recip_for_kid_or_default_for_did(crypto, resolver, kid)
+            for kid in to
+        ]
+        sender_kid = (
+            await self.default_sender_kid_for_did(resolver, frm) if frm else None
         )
+        sender_key = await secrets.get_secret_by_kid(sender_kid) if sender_kid else None
         if frm and not sender_key:
             raise PackagingServiceError("No sender key found")
 
         if sender_key:
-            return await self.crypto.ecdh_1pu_encrypt(recip_keys, sender_key, message)
+            return await crypto.ecdh_1pu_encrypt(recip_keys, sender_key, message)
         else:
-            return await self.crypto.ecdh_es_encrypt(recip_keys, message)
+            return await crypto.ecdh_es_encrypt(recip_keys, message)


### PR DESCRIPTION
By passing in all dependencies to each method that requires it rather than capturing it in the instance state. This should better support more use cases than the previous structure.

This is a backwards compatible change; the more flexible services are wrapped by the `DIDCommMessaging` class to behave exactly the same way as before. To use the new, more flexible services, use `DIDCommMessagingService` class.