### PR TITLE
fix: quickstart: Add fixes based upon previous DMP changes

### DIFF
--- a/didcomm_messaging/quickstart.py
+++ b/didcomm_messaging/quickstart.py
@@ -90,11 +90,13 @@ async def setup_default(did: DID, did_secrets: Tuple[Key, Key]) -> DIDCommMessag
     #
     # At present, the PrefixResolver is used to determine which library should
     # be used to convert a DID into a DIDDocument.
-    resolver = PrefixResolver({
-        "did:peer:2": Peer2(),
-        "did:peer:4": Peer4(),
-        "did:web:": DIDWeb(),
-    })
+    resolver = PrefixResolver(
+        {
+            "did:peer:2": Peer2(),
+            "did:peer:4": Peer4(),
+            "did:web:": DIDWeb(),
+        }
+    )
 
     # The Packaging Service is where a lot of the magic happens. Similar to a
     # shipping box, the PackagingService will "pack" and "unpack" an encrypted


### PR DESCRIPTION
Also added did:web to the default prefix resolver

These are changes that slipped through the cracks and weren't noticed until after performing an update to the latest quickstart. I'm not entirely sure how I missed them when I was trying to update the quickstart, because the quickstart should've broke without these changes.