### PR TITLE
chore: 0.1.1 release official

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "didcomm-messaging"
-version = "0.1.1a3"
+version = "0.1.1"
 description = "DIDComm Messaging implemented with swappable backends."
 authors = [
     {name = "Daniel Bluhm", email = "dbluhm@pm.me"},


### PR DESCRIPTION
This PR bumps the version in preparation for the official 0.1.1 release of didcomm-messaging-python.